### PR TITLE
add conversion from/to Ethereum functions for addresses

### DIFF
--- a/src/address/index.ts
+++ b/src/address/index.ts
@@ -75,6 +75,28 @@ export abstract class Address {
     }
   }
 
+  // based on https://github.com/filecoin-project/lotus/blob/80aa6d1d646c9984761c77dcb7cf63be094b9407/chain/types/ethtypes/eth_types.go#L370
+  static fromEthAddress = (network: Network, ethAddr: Buffer): Address => {
+    const idMask = Buffer.alloc(12)
+    idMask[0] = 0xff
+
+    if (idMask == ethAddr.slice(0,12)) {
+      return AddressId.fromBytes(network, ethAddr.slice(12))
+    }
+
+    return new FilEthAddress(network, ethAddr)  
+  }
+
+  static fromEthAddressHex = (network: Network, ethAddr: String): Address => {
+    let tmp = ethAddr
+    if (ethAddr.startsWith('0x')) {
+      tmp = ethAddr.slice(2)
+    }
+
+    const buf = Buffer.from(tmp, 'hex')
+    return this.fromEthAddress(network, buf)
+  }
+
   static isAddressId = (address: Address): address is AddressId => address.protocol == ProtocolIndicator.ID
   static isAddressBls = (address: Address): address is AddressBls => address.protocol == ProtocolIndicator.BLS
   static isAddressSecp256k1 = (address: Address): address is AddressSecp256k1 => address.protocol == ProtocolIndicator.SECP256K1
@@ -163,6 +185,16 @@ export class AddressId extends Address {
     const payload = bytes.slice(1)
     return new AddressId(network, payload)
   }
+
+  toEthAddressHex = (): String => {
+    let buf = Buffer.alloc(ETH_ADDRESS_LEN)
+    buf[0] = 0xff
+
+    buf.set(this.payload, 12)
+
+    return '0x' + buf.toString('hex')
+  }
+
 }
 
 export class AddressSecp256k1 extends Address {
@@ -314,6 +346,13 @@ export class AddressDelegated extends Address {
     const subAddress = bytes.slice(namespaceLength + 1)
 
     return new AddressDelegated(network, namespace, subAddress)
+  }
+
+  toEthAddressHex = (): String => {
+    let buf = Buffer.alloc(ETH_ADDRESS_LEN)
+    buf.set(this.payload)
+
+    return '0x' + buf.toString('hex')
   }
 }
 

--- a/tests/jest/address.test.ts
+++ b/tests/jest/address.test.ts
@@ -212,5 +212,47 @@ describe('Address', () => {
         expect(addr.subAddress.toString('hex')).toBe('23a7f3c5c663d71151f40c8610c01150c9660795')
       })
     })
+
+    describe('Ethereum conversion', async () => {
+      test('From ethereum address (ID)', async () => {
+        const addr = Address.fromEthAddressHex(Network.Testnet, '0xff00000000000000000000000000000000000001')
+
+        expect(addr.protocol).toBe(ProtocolIndicator.ID)
+        expect(addr.network).toBe(Network.Testnet)
+        expect(addr.toString()).toBe("f01")
+      })
+
+      test('From ethereum address (ID) 2', async () => {
+        const addr = Address.fromEthAddressHex(Network.Testnet, '0xff00000000000000000000000000000000000065')
+
+        expect(addr.protocol).toBe(ProtocolIndicator.ID)
+        expect(addr.network).toBe(Network.Testnet)
+        expect(addr.toString()).toBe("f0101")
+      })
+
+      test('To ethereum address (ID)', async () => {
+        const addr = AddressId.fromString('f0101')
+
+        expect(addr.toEthAddressHex()).toBe("0xff00000000000000000000000000000000000065")
+      })
+
+      test('From ethereum address (DelegatedAddress)', async () => {
+        const addr = Address.fromEthAddressHex(Network.Mainnet, '0xd4c5fb16488aa48081296299d54b0c648c9333da')
+
+        expect(addr.protocol).toBe(ProtocolIndicator.DELEGATED)
+        expect(addr.network).toBe(Network.Mainnet)
+        expect(addr.toString()).toBe("f410f2tc7wfsirksibajjmkm5ksymmsgjgm62hjnomwa")
+      })
+
+
+      test('To ethereum address (DelegatedAddress)', async () => {
+        const addr = AddressDelegated.fromString('f410f2tc7wfsirksibajjmkm5ksymmsgjgm62hjnomwa')
+
+        expect(addr.network).toBe(Network.Mainnet)
+        expect(addr.toEthAddressHex()).toBe("0xd4c5fb16488aa48081296299d54b0c648c9333da")
+      })
+
+    })
+
   })
 })


### PR DESCRIPTION
Adding function to help converting Ethereum addresses to Filecoin addresses like we did in go (see https://github.com/Zondax/rosetta-filecoin-lib/blob/master/construction_impl_test.go#L608).